### PR TITLE
Local variable expansion

### DIFF
--- a/python-vim-lldb/vim_panes.py
+++ b/python-vim-lldb/vim_panes.py
@@ -459,7 +459,7 @@ class LocalsPane(FrameKeyValuePane):
     # FIXME: allow users to customize display of args/locals/statics/scope
     self.arguments = True
     self.show_locals = True
-    self.show_statics = True
+    self.show_statics = False
     self.show_in_scope_only = True
 
   def format_variable(self, var, indent = 0):


### PR DESCRIPTION
The existing locals pane is somewhat limited in its usefulness as it
doesn't display any complex types, such as structs, or even arrays
or values stored in pointers.  This patch series adds support for
recursive expansion of variables, including being able to show in
more or less detail by making use of vim's native folds functionality.
